### PR TITLE
Added support for gonka-openai 0.2.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -675,5 +675,5 @@ HELP_AND_FAQ_URL=https://gonka.ai
 # Optional override for your Gonka network address.
 #
 GONKA_PRIVATE_KEY=
-GONKA_ENDPOINTS=http://195.242.13.239:8000/v1
+GONKA_SOURCE_URL=http://195.242.13.239:8000
 GONKA_ADDRESS=

--- a/README.txt
+++ b/README.txt
@@ -9,10 +9,11 @@ git checkout stable_version
 # Set our parameters
 cp .env.example .env
 sudo nano .env
-    OPENAI_API_KEY=
+    OPENAI_API_KEY= // Adds OpenAI in the Models List
     GONKA_PRIVATE_KEY=
-    GONKA_ENDPOINTS=
+    GONKA_SOURCE_URL=
     GONKA_ADDRESS=
+    RAG_OPENAI_API_KEY= // Use all default RAG settings and real OpenAI key while Gonka does not support /v1/embeddings endpoint
 
 cp librechat.example-gonka.yaml librechat.yaml
 sudo nano librechat.yaml

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -1,7 +1,7 @@
 const { OllamaClient } = require('./OllamaClient');
 const { HttpsProxyAgent } = require('https-proxy-agent');
 const { SplitStreamHandler, CustomOpenAIClient: OpenAI } = require('@librechat/agents');
-const { gonkaFetch } = require('gonka-openai');
+const { gonkaFetch, resolveAndSelectEndpoint } = require('gonka-openai');
 const {
   isEnabled,
   Tokenizer,
@@ -1170,6 +1170,15 @@ ${convo}
         fetchOptions: {},
       };
 
+      // Gonka: override baseURL with selected endpoint URL
+      let selectedEndpoint;
+      if (this.options.endpoint === 'Gonka AI') {
+        const sourceUrl = process.env.GONKA_SOURCE_URL;
+        const result = await resolveAndSelectEndpoint({ sourceUrl });
+        selectedEndpoint = result.selected;
+        opts.baseURL = selectedEndpoint.url;
+      }
+
       if (this.useOpenRouter) {
         opts.defaultHeaders = {
           'HTTP-Referer': 'https://librechat.ai',
@@ -1284,7 +1293,8 @@ ${convo}
       */
       const fetch = (this.options.endpoint === 'Gonka AI')
           ? gonkaFetch({
-            gonkaPrivateKey: this.gonkaPrivateKey
+            gonkaPrivateKey: this.gonkaPrivateKey,
+            selectedEndpoint
           })
         : createFetch({
           directEndpoint: this.options.directEndpoint,

--- a/api/package.json
+++ b/api/package.json
@@ -71,7 +71,7 @@
     "express-static-gzip": "^2.2.0",
     "file-type": "^18.7.0",
     "firebase": "^11.0.2",
-    "gonka-openai": "^0.2.1",
+    "gonka-openai": "^0.2.2",
     "googleapis": "^126.0.1",
     "handlebars": "^4.7.7",
     "https-proxy-agent": "^7.0.6",


### PR DESCRIPTION
Actual endpoint now randomly selected with resolveEndpoints

const endpoints = await resolveEndpoints({ sourceUrl: 'http://195.242.13.239:8000' });
const client = new GonkaOpenAI({
  gonkaPrivateKey: process.env.GONKA_PRIVATE_KEY,
  endpoints,
});