### PR TITLE
Debug/kimi k2 streaming

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -1222,11 +1222,7 @@ ${convo}
         modelOptions.prompt = payload;
       }
 
-      // ==== GONKA: force fixed max_tokens for Gonka AI ====
-      if (this.options.endpoint === 'Gonka AI') {
-        modelOptions.max_tokens = 16384;
-      }
-      // ==== /GONKA ====
+
 
       const baseURL = extractBaseURL(this.completionsUrl);
       logger.debug('[OpenAIClient] chatCompletion', { baseURL, modelOptions });

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -1224,7 +1224,7 @@ ${convo}
 
       // ==== GONKA: force fixed max_tokens for Gonka AI ====
       if (this.options.endpoint === 'Gonka AI') {
-        modelOptions.max_tokens = 8192;
+        modelOptions.max_tokens = 16384;
       }
       // ==== /GONKA ====
 

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -1508,17 +1508,6 @@ ${convo}
       }
       /* ==== /GONKA ==== */
 
-      // TMP DEBUG — request payload
-      console.log('[GONKA-DEBUG] REQUEST:', JSON.stringify({
-        model: bodyToSend.model,
-        max_tokens: bodyToSend.max_tokens,
-        stream: bodyToSend.stream,
-        endpoint: opts.baseURL,
-        messagesCount: bodyToSend.messages?.length,
-        firstMsgRole: bodyToSend.messages?.[0]?.role,
-      }, null, 2));
-      // /TMP DEBUG
-
       if (modelOptions.stream) {
         streamPromise = new Promise((resolve) => {
           streamResolve = resolve;
@@ -1602,16 +1591,6 @@ ${convo}
             }
           } catch { /* no-op */ }
 
-          // TMP DEBUG — each stream chunk
-          console.log('[GONKA-DEBUG] CHUNK:', JSON.stringify({
-            deltaKeys: Object.keys(chunk?.choices?.[0]?.delta || {}),
-            content: chunk?.choices?.[0]?.delta?.content?.substring(0, 50),
-            reasoning: chunk?.choices?.[0]?.delta?.reasoning?.substring(0, 50),
-            reasoning_content: chunk?.choices?.[0]?.delta?.reasoning_content?.substring(0, 50),
-            finish_reason: chunk?.choices?.[0]?.finish_reason,
-          }));
-          // /TMP DEBUG
-
           // ==== GONKA: normalize reasoning key to OpenAI standard ====
           const delta = chunk?.choices?.[0]?.delta;
           if (delta && 'reasoning' in delta && !('reasoning_content' in delta)) {
@@ -1673,16 +1652,6 @@ ${convo}
 
       const { message, finish_reason } = choices[0] ?? {};
       this.metadata = { finish_reason };
-
-      // TMP DEBUG — stream result summary
-      console.log('[GONKA-DEBUG] RESULT:', JSON.stringify({
-        tokens: this.streamHandler.tokens.length,
-        reasoningTokens: this.streamHandler.reasoningTokens.length,
-        finish_reason,
-        messageContent: message?.content?.substring(0, 100),
-        messageRole: message?.role,
-      }));
-      // /TMP DEBUG
 
       logger.debug('[OpenAIClient] chatCompletion response', chatCompletion);
 
@@ -1751,9 +1720,6 @@ ${convo}
           throw err;
         }
       } else {
-        // TMP DEBUG — unhandled error details
-        console.log('[GONKA-DEBUG] ERROR:', err?.name, err?.message, err?.constructor?.name, err?.stack?.substring(0, 500));
-        // /TMP DEBUG
         logger.error('[OpenAIClient.chatCompletion] Unhandled error type', err);
         throw err;
       }

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -1612,6 +1612,14 @@ ${convo}
           }));
           // /TMP DEBUG
 
+          // ==== GONKA: normalize reasoning key to OpenAI standard ====
+          const delta = chunk?.choices?.[0]?.delta;
+          if (delta && 'reasoning' in delta && !('reasoning_content' in delta)) {
+            delta.reasoning_content = delta.reasoning;
+            delete delta.reasoning;
+          }
+          // ==== /GONKA ====
+
           this.streamHandler.handle(chunk);
           if (abortController.signal.aborted) {
             stream.controller.abort();

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -1224,7 +1224,7 @@ ${convo}
 
       // ==== GONKA: force fixed max_tokens for Gonka AI ====
       if (this.options.endpoint === 'Gonka AI') {
-        modelOptions.max_tokens = 1000;
+        modelOptions.max_tokens = 8192;
       }
       // ==== /GONKA ====
 
@@ -1508,6 +1508,17 @@ ${convo}
       }
       /* ==== /GONKA ==== */
 
+      // TMP DEBUG — request payload
+      console.log('[GONKA-DEBUG] REQUEST:', JSON.stringify({
+        model: bodyToSend.model,
+        max_tokens: bodyToSend.max_tokens,
+        stream: bodyToSend.stream,
+        endpoint: opts.baseURL,
+        messagesCount: bodyToSend.messages?.length,
+        firstMsgRole: bodyToSend.messages?.[0]?.role,
+      }, null, 2));
+      // /TMP DEBUG
+
       if (modelOptions.stream) {
         streamPromise = new Promise((resolve) => {
           streamResolve = resolve;
@@ -1591,6 +1602,16 @@ ${convo}
             }
           } catch { /* no-op */ }
 
+          // TMP DEBUG — each stream chunk
+          console.log('[GONKA-DEBUG] CHUNK:', JSON.stringify({
+            deltaKeys: Object.keys(chunk?.choices?.[0]?.delta || {}),
+            content: chunk?.choices?.[0]?.delta?.content?.substring(0, 50),
+            reasoning: chunk?.choices?.[0]?.delta?.reasoning?.substring(0, 50),
+            reasoning_content: chunk?.choices?.[0]?.delta?.reasoning_content?.substring(0, 50),
+            finish_reason: chunk?.choices?.[0]?.finish_reason,
+          }));
+          // /TMP DEBUG
+
           this.streamHandler.handle(chunk);
           if (abortController.signal.aborted) {
             stream.controller.abort();
@@ -1644,6 +1665,16 @@ ${convo}
 
       const { message, finish_reason } = choices[0] ?? {};
       this.metadata = { finish_reason };
+
+      // TMP DEBUG — stream result summary
+      console.log('[GONKA-DEBUG] RESULT:', JSON.stringify({
+        tokens: this.streamHandler.tokens.length,
+        reasoningTokens: this.streamHandler.reasoningTokens.length,
+        finish_reason,
+        messageContent: message?.content?.substring(0, 100),
+        messageRole: message?.role,
+      }));
+      // /TMP DEBUG
 
       logger.debug('[OpenAIClient] chatCompletion response', chatCompletion);
 
@@ -1712,6 +1743,9 @@ ${convo}
           throw err;
         }
       } else {
+        // TMP DEBUG — unhandled error details
+        console.log('[GONKA-DEBUG] ERROR:', err?.name, err?.message, err?.constructor?.name, err?.stack?.substring(0, 500));
+        // /TMP DEBUG
         logger.error('[OpenAIClient.chatCompletion] Unhandled error type', err);
         throw err;
       }

--- a/librechat.example-gonka.yaml
+++ b/librechat.example-gonka.yaml
@@ -13,30 +13,35 @@ endpoints:
       models:
         default:
           [
-            'Qwen/QwQ-32B',
-            'Qwen/Qwen2.5-7B-Instruct'
+            'Qwen/Qwen3-235B-A22B-Instruct-2507-FP8',
+            'moonshotai/Kimi-K2.6',
           ]
         fetch: false
       titleConvo: true
-      titleModel: "Qwen/Qwen2.5-7B-Instruct" # non-reasonable modele should be used as titleModel
+      titleModel: "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8"
       summarize: false
       summaryModel: "current_model"
       forcePrompt: false
       modelDisplayLabel: "Gonka AI"
       iconURL: "https://gonka.ai/images/01-favicon.png"
+      addParams:
+        max_tokens: 16384
+        thinking:
+          type: "disabled"
 modelSpecs:
   prioritize: true
   list:
-    - name: "qwen-32b"
-      label: "Qwen/QwQ-32B"
+    - name: "Qwen3-235B-Instruct"
+      label: "Qwen3-235B-Instruct"
       default: true
       preset:
         endpoint: "Gonka AI"
-        model: "Qwen/QwQ-32B"
-        modelLabel: "Qwen/QwQ-32B"
-    - name: "qwen-7b"
-      label: "Qwen/Qwen2.5-7B-Instruct"
+        model: "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8"
+        modelLabel: "Qwen3-235B-Instruct"
+    - name: "Kimi-K2.6"
+      label: "Kimi-K2.6"
+      default: false
       preset:
         endpoint: "Gonka AI"
-        model: "Qwen/Qwen2.5-7B-Instruct"
-        modelLabel: "Qwen/Qwen2.5-7B-Instruct"
+        model: "moonshotai/Kimi-K2.6"
+        modelLabel: "Kimi-K2.6"


### PR DESCRIPTION
- Fixed Kimi-K2.6 streaming failures caused by hardcoded max_tokens: 1000 — reasoning consumed entire token budget leaving nothing for content
- Added delta.reasoning → delta.reasoning_content normalization for Kimi compatibility (Gonka nodes send non-standard field name)
- Disabled Kimi thinking via addParams in yaml to work around Gonka node ~2000 token server-side limit
- Moved max_tokens and thinking config from hardcoded JS to librechat.yaml addParams